### PR TITLE
operator fix nil pointer issue when first deployed

### DIFF
--- a/charts/monosql-operator/Chart.yaml
+++ b/charts/monosql-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: monosql-operator
 description: monosql-operator Helm chart for Kubernetes
-version: 1.0.0 
-appVersion: "1.0.0"
+version: 1.0.1 
+appVersion: "1.0.1"
 keywords:
   - database
   - newsql

--- a/charts/monosql-operator/values.yaml
+++ b/charts/monosql-operator/values.yaml
@@ -14,7 +14,7 @@ controllerManager:
   serviceAccount: "monosql-operator-sa"
   image:
     repository: monographdb/monosql-operator
-    tag: v1.0.0
+    tag: v1.0.1
     pullPolicy: IfNotPresent
   ## In case the above image is pulled from a registry that requires
   ## authentication, a secret containining credentials can be added


### PR DESCRIPTION
## What problem does this PR solve?

Update `MonoSQL Operator` version to 1.0.1, CRD is updated synchronously. 

Operator fixed nil pointer bug when first create statefulset .

## What is changed, and how does it work?

> NONE

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)