### PR TITLE
Update monosql operator version to 1.2.2

### DIFF
--- a/charts/monosql-operator/Chart.yaml
+++ b/charts/monosql-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: monosql-operator
 description: monosql-operator Helm chart for Kubernetes
-version: 1.0.2 
-appVersion: "1.0.2"
+version: 1.2.2 
+appVersion: "1.2.2"
 keywords:
   - database
   - newsql

--- a/charts/monosql-operator/values.yaml
+++ b/charts/monosql-operator/values.yaml
@@ -14,7 +14,7 @@ controllerManager:
   serviceAccount: "monosql-operator-sa"
   image:
     repository: monographdb/monosql-operator
-    tag: v1.0.2
+    tag: v1.2.2
     pullPolicy: IfNotPresent
   ## In case the above image is pulled from a registry that requires
   ## authentication, a secret containining credentials can be added


### PR DESCRIPTION
## What problem does this PR solve?

Update `MonoSQL Operator` version to 1.2.2 .  

The MonoSQL Operator use `monosql-configmap-monosql-start` instead of start cmd.

## What is changed, and how does it work?

> NONE

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)